### PR TITLE
Use test mixin for contracting-v1-specific cases

### DIFF
--- a/openprocurement/auctions/flash/tests/contract.py
+++ b/openprocurement/auctions/flash/tests/contract.py
@@ -19,9 +19,16 @@ from openprocurement.auctions.flash.tests.blanks.contract_blanks import (
     # AuctionContractResourceTest
     patch_auction_contract,
 )
+from openprocurement.auctions.core.plugins.contracting.v1.tests.contract import (
+    AuctionContractV1ResourceTestCaseMixin
+)
 
 
-class AuctionContractResourceTest(BaseAuctionWebTest, AuctionContractResourceTestMixin):
+class AuctionContractResourceTest(
+    BaseAuctionWebTest,
+    AuctionContractResourceTestMixin,
+     AuctionContractV1ResourceTestCaseMixin
+):
     initial_status = 'active.qualification'
     initial_bids = test_bids
     initial_organization = test_organization


### PR DESCRIPTION
**Depends on [PR](https://github.com/openprocurement/openprocurement.auctions.core/pull/48) in CORE**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.auctions.flash/43)
<!-- Reviewable:end -->
