### PR TITLE
Remove usage of 'admins' token in tests

### DIFF
--- a/openprocurement/auctions/flash/tests/auction.py
+++ b/openprocurement/auctions/flash/tests/auction.py
@@ -778,7 +778,8 @@ class AuctionMultipleLotAuctionResourceTest(AuctionAuctionResourceTest):
 
         for lot in self.initial_lots:
             response = self.app.patch_json(
-                '/auctions/{}/auction/{}'.format(self.auction_id, lot['id']), {'data': patch_data})
+                '/auctions/{}/auction/{}'.format(self.auction_id, lot['id']), {'data': patch_data}
+            )
             self.assertEqual(response.status, '200 OK')
             self.assertEqual(response.content_type, 'application/json')
             auction = response.json['data']
@@ -794,12 +795,15 @@ class AuctionMultipleLotAuctionResourceTest(AuctionAuctionResourceTest):
             patch_data["lots"][0]['auctionUrl'])
 
         self.app.authorization = ('Basic', ('broker', ''))
-        response = self.app.post_json('/auctions/{}/cancellations?acc_token={}'.format(self.auction_id, self.auction_token), {'data': {
-            'reason': 'cancellation reason',
-            'status': 'active',
-            "cancellationOf": "lot",
-            "relatedLot": self.initial_lots[0]['id']
-        }})
+        response = self.app.post_json(
+            '/auctions/{}/cancellations?acc_token={}'.format(
+                self.auction_id, self.auction_token
+            ), {'data': {'reason': 'cancellation reason',
+                         'status': 'active',
+                         'cancellationOf': 'lot',
+                         'relatedLot': self.initial_lots[0]['id']}
+                }
+        )
         self.assertEqual(response.status, '201 Created')
 
         self.app.authorization = ('Basic', ('auction', ''))

--- a/openprocurement/auctions/flash/tests/auction.py
+++ b/openprocurement/auctions/flash/tests/auction.py
@@ -59,6 +59,7 @@ class AuctionLotAuctionResourceTest(
     initial_lots = test_lots
 
     def test_get_auction_auction(self):
+        self.app.authorization = ('Basic', ('auction', ''))
         response = self.app.get(
             '/auctions/{}/auction'.format(self.auction_id), status=403)
         self.assertEqual(response.status, '403 Forbidden')
@@ -442,6 +443,7 @@ class AuctionMultipleLotAuctionResourceTest(AuctionAuctionResourceTest):
     initial_lots = 2 * test_lots
 
     def test_get_auction_auction(self):
+        self.app.authorization = ('Basic', ('auction', ''))
         response = self.app.get(
             '/auctions/{}/auction'.format(self.auction_id), status=403)
         self.assertEqual(response.status, '403 Forbidden')
@@ -791,16 +793,13 @@ class AuctionMultipleLotAuctionResourceTest(AuctionAuctionResourceTest):
             auction["lots"][0]['auctionUrl'],
             patch_data["lots"][0]['auctionUrl'])
 
-        self.app.authorization = ('Basic', ('token', ''))
-        response = self.app.post_json(
-            '/auctions/{}/cancellations'.format(
-                self.auction_id),
-            {
-                'data': {
-                    'reason': 'cancellation reason',
-                    'status': 'active',
-                    "cancellationOf": "lot",
-                    "relatedLot": self.initial_lots[0]['id']}})
+        self.app.authorization = ('Basic', ('broker', ''))
+        response = self.app.post_json('/auctions/{}/cancellations?acc_token={}'.format(self.auction_id, self.auction_token), {'data': {
+            'reason': 'cancellation reason',
+            'status': 'active',
+            "cancellationOf": "lot",
+            "relatedLot": self.initial_lots[0]['id']
+        }})
         self.assertEqual(response.status, '201 Created')
 
         self.app.authorization = ('Basic', ('auction', ''))

--- a/openprocurement/auctions/flash/tests/award.py
+++ b/openprocurement/auctions/flash/tests/award.py
@@ -145,7 +145,7 @@ class AuctionLotAwardComplaintResourceTest(
     def setUp(self):
         super(AuctionLotAwardComplaintResourceTest, self).setUp()
         # Create award
-        fixtures.create_award( self)
+        fixtures.create_award(self)
 
     def test_create_auction_award_complaint(self):
         response = self.app.post_json(
@@ -181,7 +181,7 @@ class Auction2LotAwardComplaintResourceTest(
     def setUp(self):
         super(Auction2LotAwardComplaintResourceTest, self).setUp()
         # Create award
-        fixtures.create_award( self)
+        fixtures.create_award(self)
 
     test_get_auction_lot_award_complaint = snitch(get_auction_award_complaint)
     test_get_auction_lot_award_complaints = snitch(
@@ -320,8 +320,8 @@ class Auction2LotAwardDocumentResourceTest(
         response = self.app.post(
             '/auctions/{}/awards/{}/documents?acc_token={}'.format(
                 self.auction_id, self.award_id, self.auction_token
-        ), upload_files=[
-                ('file', 'name.doc', 'content')])
+            ), upload_files=[('file', 'name.doc', 'content')]
+        )
         self.assertEqual(response.status, '201 Created')
         self.assertEqual(response.content_type, 'application/json')
         doc_id = response.json["data"]['id']
@@ -393,8 +393,8 @@ class Auction2LotAwardDocumentResourceTest(
         response = self.app.post(
             '/auctions/{}/awards/{}/documents?acc_token={}'.format(
                 self.auction_id, self.award_id, self.auction_token
-        ), upload_files=[
-                ('file', 'name.doc', 'content')], status=403)
+            ), upload_files=[('file', 'name.doc', 'content')], status=403
+        )
         self.assertEqual(response.status, '403 Forbidden')
         self.assertEqual(response.content_type, 'application/json')
         self.assertEqual(
@@ -405,8 +405,8 @@ class Auction2LotAwardDocumentResourceTest(
         response = self.app.post(
             '/auctions/{}/awards/{}/documents?acc_token={}'.format(
                 self.auction_id, self.award_id, self.auction_token
-        ), upload_files=[
-                ('file', 'name.doc', 'content')])
+            ), upload_files=[('file', 'name.doc', 'content')]
+        )
         self.assertEqual(response.status, '201 Created')
         self.assertEqual(response.content_type, 'application/json')
         doc_id = response.json["data"]['id']
@@ -459,9 +459,8 @@ class Auction2LotAwardDocumentResourceTest(
                 self.auction_id,
                 self.award_id,
                 doc_id, self.auction_token
-        ),
-            'content3',
-            content_type='application/msword')
+            ), 'content3', content_type='application/msword'
+        )
         self.assertEqual(response.status, '200 OK')
         self.assertEqual(response.content_type, 'application/json')
         self.assertEqual(doc_id, response.json["data"]["id"])
@@ -491,8 +490,8 @@ class Auction2LotAwardDocumentResourceTest(
         response = self.app.put(
             '/auctions/{}/awards/{}/documents/{}?acc_token={}'.format(
                 self.auction_id, self.award_id, doc_id, self.auction_token
-        ), upload_files=[
-                ('file', 'name.doc', 'content3')], status=403)
+            ), upload_files=[('file', 'name.doc', 'content3')], status=403
+        )
         self.assertEqual(response.status, '403 Forbidden')
         self.assertEqual(response.content_type, 'application/json')
         self.assertEqual(
@@ -503,8 +502,8 @@ class Auction2LotAwardDocumentResourceTest(
         response = self.app.post(
             '/auctions/{}/awards/{}/documents?acc_token={}'.format(
                 self.auction_id, self.award_id, self.auction_token
-        ), upload_files=[
-                ('file', 'name.doc', 'content')])
+            ), upload_files=[('file', 'name.doc', 'content')]
+        )
         self.assertEqual(response.status, '201 Created')
         self.assertEqual(response.content_type, 'application/json')
         doc_id = response.json["data"]['id']
@@ -536,12 +535,11 @@ class Auction2LotAwardDocumentResourceTest(
             '/auctions/{}/cancellations?acc_token={}'.format(
                 self.auction_id,
                 self.auction_token
-            ),
-                {'data': {
-                'reason': 'cancellation reason',
-                'status': 'active',
-                "cancellationOf": "lot",
-                "relatedLot": self.initial_lots[0]['id']}}
+            ), {'data': {'reason': 'cancellation reason',
+                         'status': 'active',
+                         'cancellationOf': 'lot',
+                         'relatedLot': self.initial_lots[0]['id']}
+                }
         )
         self.assertEqual(response.status, '201 Created')
 

--- a/openprocurement/auctions/flash/tests/blanks/bidder_blanks.py
+++ b/openprocurement/auctions/flash/tests/blanks/bidder_blanks.py
@@ -90,8 +90,7 @@ def create_auction_bidder_invalid(self):
             u'identifier': [u'Please use a mapping for this field or '
                             u'Identifier instance instead of unicode.']},
           u'location': u'body',
-          u'name': u'tenderers'}
-        ]
+          u'name': u'tenderers'}]
     )
 
     response = self.app.post_json(
@@ -102,30 +101,34 @@ def create_auction_bidder_invalid(self):
     self.assertEqual(response.status, '422 Unprocessable Entity')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['status'], 'error')
-    self.assertEqual(response.json['errors'],
-     [{u'description': [{u'contactPoint': [u'This field is required.'],
-                         u'identifier': {
-                             u'scheme': [u'This field is required.'],
-                             u'id': [u'This field is required.']},
-                         u'name': [u'This field is required.'],
-                         u'address': [u'This field is required.']}],
-         u'location': u'body',
-         u'name': u'tenderers'}])
+    self.assertEqual(
+        response.json['errors'],
+        [{u'description': [{u'contactPoint': [u'This field is required.'],
+                            u'identifier': {
+                            u'scheme': [u'This field is required.'],
+                            u'id': [u'This field is required.']},
+                            u'name': [u'This field is required.'],
+                            u'address': [u'This field is required.']}],
+          u'location': u'body',
+          u'name': u'tenderers'}]
+    )
 
     response = self.app.post_json(request_path, {'data': {'tenderers': [{
         'name': 'name', 'identifier': {'uri': 'invalid_value'}}]}}, status=422)
     self.assertEqual(response.status, '422 Unprocessable Entity')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['status'], 'error')
-    self.assertEqual(response.json['errors'],
-     [{u'description': [
-         {u'contactPoint': [u'This field is required.'],
-          u'identifier': {u'scheme': [u'This field is required.'],
-                          u'id': [u'This field is required.'],
-                          u'uri': [u'Not a well formed URL.']},
-                          u'address': [u'This field is required.']}],
-         u'location': u'body',
-         u'name': u'tenderers'}]
+    self.assertEqual(
+        response.json['errors'],
+        [{u'description': [
+             {u'contactPoint': [u'This field is required.'],
+              u'identifier': {u'scheme': [u'This field is required.'],
+                              u'id': [u'This field is required.'],
+                              u'uri': [u'Not a well formed URL.']},
+              u'address': [u'This field is required.']}
+          ],
+          u'location': u'body',
+          u'name': u'tenderers'}]
      )
 
     response = self.app.post_json(
@@ -138,14 +141,15 @@ def create_auction_bidder_invalid(self):
     self.assertEqual(
         response.json['errors'],
         [{u'description': [u'This field is required.'],
-        u'location': u'body',
-        u'name': u'value'}])
+          u'location': u'body',
+          u'name': u'value'}]
+    )
 
     response = self.app.post_json(
-        request_path, {
-            'data': {
-                'tenderers': [test_organization], "value": {
-                "amount": 500, 'valueAddedTaxIncluded': False}}}, status=422
+        request_path, {'data': {
+            'tenderers': [test_organization], "value": {
+                'amount': 500, 'valueAddedTaxIncluded': False
+            }}}, status=422
     )
     self.assertEqual(response.status, '422 Unprocessable Entity')
     self.assertEqual(response.content_type, 'application/json')
@@ -173,10 +177,9 @@ def create_auction_bidder_invalid(self):
         [{u'description': [
             u'currency of bid should be identical to '
             u'currency of value of auction'
-        ],
-        u'location': u'body',
-        u'name': u'value'
-        }]
+          ],
+          u'location': u'body',
+          u'name': u'value'}]
     )
 
     response = self.app.post_json(
@@ -416,22 +419,27 @@ def get_auction_bidder(self):
 
     response = self.app.delete(
         '/auctions/{}/bids/{}?acc_token={}'.format(
-        self.auction_id, bidder['id'], bid_token
-    ), status=403)
+            self.auction_id, bidder['id'], bid_token
+        ), status=403
+    )
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(
         response.json['errors'][0]["description"],
-        "Can't delete bid in current (active.qualification) auction status")
+        "Can't delete bid in current (active.qualification) auction status"
+    )
 
 
 def delete_auction_bidder(self):
     response = self.app.post_json(
         '/auctions/{}/bids'.format(
-            self.auction_id), {
-            'data': {
+            self.auction_id
+        ), {'data': {
                 'tenderers': [test_organization], "value": {
-                    "amount": 500}}})
+                    "amount": 500
+                }
+            }}
+    )
     self.assertEqual(response.status, '201 Created')
     self.assertEqual(response.content_type, 'application/json')
     bidder = response.json['data']
@@ -439,8 +447,9 @@ def delete_auction_bidder(self):
 
     response = self.app.delete(
         '/auctions/{}/bids/{}?acc_token={}'.format(
-        self.auction_id, bidder['id'], bid_token
-    ))
+            self.auction_id, bidder['id'], bid_token
+        )
+    )
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['data'], bidder)
@@ -603,8 +612,8 @@ def create_auction_bidder_document_nopending(self):
     response = self.app.post(
         '/auctions/{}/bids/{}/documents?acc_token={}'.format(
             self.auction_id, bid_id, bid_token
-    ), upload_files=[
-            ('file', 'name.doc', 'content')])
+        ), upload_files=[('file', 'name.doc', 'content')]
+    )
     self.assertEqual(response.status, '201 Created')
     self.assertEqual(response.content_type, 'application/json')
     doc_id = response.json["data"]['id']
@@ -615,9 +624,8 @@ def create_auction_bidder_document_nopending(self):
     response = self.app.patch_json(
         '/auctions/{}/bids/{}/documents/{}?acc_token={}'.format(
             self.auction_id, bid_id, doc_id, bid_token
-    ), {
-            "data": {
-                "description": "document description"}}, status=403)
+        ), {"data": {"description": "document description"}}, status=403
+    )
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(
@@ -629,10 +637,11 @@ def create_auction_bidder_document_nopending(self):
             self.auction_id,
             bid_id,
             doc_id, bid_token
-    ),
+        ),
         'content3',
         content_type='application/msword',
-        status=403)
+        status=403
+    )
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(
@@ -642,8 +651,8 @@ def create_auction_bidder_document_nopending(self):
     response = self.app.post(
         '/auctions/{}/bids/{}/documents?acc_token={}'.format(
             self.auction_id, bid_id, bid_token
-    ), upload_files=[
-            ('file', 'name.doc', 'content')], status=403)
+        ), upload_files=[('file', 'name.doc', 'content')], status=403
+    )
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(

--- a/openprocurement/auctions/flash/tests/blanks/bidder_blanks.py
+++ b/openprocurement/auctions/flash/tests/blanks/bidder_blanks.py
@@ -28,10 +28,13 @@ def create_auction_bidder_invalid(self):
     self.assertEqual(response.status, '415 Unsupported Media Type')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['status'], 'error')
-    self.assertEqual(response.json['errors'],
-                     [{u'description': u"Content-Type header should be one of ['application/json']",
-                       u'location': u'header',
-                       u'name': u'Content-Type'}])
+    self.assertEqual(
+        response.json['errors'],
+        [{u'description': u"Content-Type header should be one of "
+                          u"['application/json']",
+          u'location': u'header',
+          u'name': u'Content-Type'}]
+    )
 
     response = self.app.post(
         request_path, 'data', content_type='application/json', status=422)
@@ -73,33 +76,41 @@ def create_auction_bidder_invalid(self):
             u'body', u'name': u'invalid_field'}
     ])
 
-    response = self.app.post_json(request_path, {'data': {'tenderers': [
-                                  {'identifier': 'invalid_value'}]}}, status=422)
+    response = self.app.post_json(
+        request_path,
+        {'data': {'tenderers': [{'identifier': 'invalid_value'}]}},
+        status=422
+    )
     self.assertEqual(response.status, '422 Unprocessable Entity')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['status'], 'error')
     self.assertEqual(
         response.json['errors'],
-        [
-            {
-                u'description': {
-                    u'identifier': [u'Please use a mapping for this field or Identifier instance instead of unicode.']},
-                u'location': u'body',
-                u'name': u'tenderers'}])
+        [{u'description': {
+            u'identifier': [u'Please use a mapping for this field or '
+                            u'Identifier instance instead of unicode.']},
+          u'location': u'body',
+          u'name': u'tenderers'}
+        ]
+    )
 
     response = self.app.post_json(
-        request_path, {'data': {'tenderers': [{'identifier': {}}]}}, status=422)
+        request_path,
+        {'data': {'tenderers': [{'identifier': {}}]}},
+        status=422
+    )
     self.assertEqual(response.status, '422 Unprocessable Entity')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['status'], 'error')
     self.assertEqual(response.json['errors'],
-                     [{u'description': [{u'contactPoint': [u'This field is required.'],
-                                         u'identifier': {u'scheme': [u'This field is required.'],
-                                                         u'id': [u'This field is required.']},
-                                         u'name': [u'This field is required.'],
-                                         u'address': [u'This field is required.']}],
-                         u'location': u'body',
-                         u'name': u'tenderers'}])
+     [{u'description': [{u'contactPoint': [u'This field is required.'],
+                         u'identifier': {
+                             u'scheme': [u'This field is required.'],
+                             u'id': [u'This field is required.']},
+                         u'name': [u'This field is required.'],
+                         u'address': [u'This field is required.']}],
+         u'location': u'body',
+         u'name': u'tenderers'}])
 
     response = self.app.post_json(request_path, {'data': {'tenderers': [{
         'name': 'name', 'identifier': {'uri': 'invalid_value'}}]}}, status=422)
@@ -107,13 +118,15 @@ def create_auction_bidder_invalid(self):
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['status'], 'error')
     self.assertEqual(response.json['errors'],
-                     [{u'description': [{u'contactPoint': [u'This field is required.'],
-                                         u'identifier': {u'scheme': [u'This field is required.'],
-                                                         u'id': [u'This field is required.'],
-                                                         u'uri': [u'Not a well formed URL.']},
-                                         u'address': [u'This field is required.']}],
-                         u'location': u'body',
-                         u'name': u'tenderers'}])
+     [{u'description': [
+         {u'contactPoint': [u'This field is required.'],
+          u'identifier': {u'scheme': [u'This field is required.'],
+                          u'id': [u'This field is required.'],
+                          u'uri': [u'Not a well formed URL.']},
+                          u'address': [u'This field is required.']}],
+         u'location': u'body',
+         u'name': u'tenderers'}]
+     )
 
     response = self.app.post_json(
         request_path, {
@@ -122,23 +135,27 @@ def create_auction_bidder_invalid(self):
     self.assertEqual(response.status, '422 Unprocessable Entity')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['status'], 'error')
-    self.assertEqual(response.json['errors'], [{u'description': [
-                     u'This field is required.'], u'location': u'body', u'name': u'value'}])
+    self.assertEqual(
+        response.json['errors'],
+        [{u'description': [u'This field is required.'],
+        u'location': u'body',
+        u'name': u'value'}])
 
     response = self.app.post_json(
         request_path, {
             'data': {
                 'tenderers': [test_organization], "value": {
-                    "amount": 500, 'valueAddedTaxIncluded': False}}}, status=422)
+                "amount": 500, 'valueAddedTaxIncluded': False}}}, status=422
+    )
     self.assertEqual(response.status, '422 Unprocessable Entity')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['status'], 'error')
     self.assertEqual(
         response.json['errors'],
-        [{
-            u'description': [
-                u'valueAddedTaxIncluded of bid should be identical to valueAddedTaxIncluded of value of auction'
-            ],
+        [{u'description': [
+            u'valueAddedTaxIncluded of bid should be identical '
+            u'to valueAddedTaxIncluded of value of auction'
+        ],
             u'location': u'body', u'name': u'value'
         }]
     )
@@ -153,12 +170,12 @@ def create_auction_bidder_invalid(self):
     self.assertEqual(response.json['status'], 'error')
     self.assertEqual(
         response.json['errors'],
-        [{
-            u'description': [
-                u'currency of bid should be identical to currency of value of auction'
-            ],
-            u'location': u'body',
-            u'name': u'value'
+        [{u'description': [
+            u'currency of bid should be identical to '
+            u'currency of value of auction'
+        ],
+        u'location': u'body',
+        u'name': u'value'
         }]
     )
 
@@ -170,16 +187,17 @@ def create_auction_bidder_invalid(self):
     self.assertEqual(response.status, '422 Unprocessable Entity')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['status'], 'error')
-    self.assertEqual(response.json['errors'],
-                     [{u'description': u"invalid literal for int() with base 10: 'contactPoint'",
-                       u'location': u'body',
-                       u'name': u'data'},
-                      ])
+    self.assertEqual(
+        response.json['errors'],
+        [{u'description': u"invalid literal for int() with base 10: "
+                          u"'contactPoint'",
+          u'location': u'body',
+          u'name': u'data'}]
+    )
 
 
 def create_auction_bidder(self):
     dateModified = self.db.get(self.auction_id).get('dateModified')
-
     response = self.app.post_json(
         '/auctions/{}/bids'.format(
             self.auction_id), {
@@ -219,16 +237,17 @@ def patch_auction_bidder(self):
             self.auction_id), {
             'data': {
                 'tenderers': [test_organization], "status": "draft", "value": {
-                    "amount": 500}}})
+                    "amount": 500}}}
+    )
     self.assertEqual(response.status, '201 Created')
     self.assertEqual(response.content_type, 'application/json')
     bidder = response.json['data']
+    bid_token = response.json['access']['token']
     response = self.app.patch_json(
-        '/auctions/{}/bids/{}'.format(
-            self.auction_id, bidder['id']), {
-            "data": {
-                "value": {
-                    "amount": 60}}}, status=422)
+        '/auctions/{}/bids/{}?acc_token={}'.format(
+            self.auction_id, bidder['id'], bid_token
+        ), {"data": {"value": {"amount": 60}}}, status=422
+    )
     self.assertEqual(response.status, '422 Unprocessable Entity')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['status'], 'error')
@@ -242,8 +261,13 @@ def patch_auction_bidder(self):
         }]
     )
 
-    response = self.app.patch_json('/auctions/{}/bids/{}'.format(self.auction_id, bidder['id']), {
-                                   "data": {'tenderers': [{"name": u"Державне управління управлінням справами"}]}})
+    response = self.app.patch_json('/auctions/{}/bids/{}?acc_token={}'.format(
+        self.auction_id, bidder['id'], bid_token
+    ), {"data": {
+        'tenderers': [
+            {"name": u"Державне управління управлінням справами"}
+        ]}}
+    )
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['data']['date'], bidder['date'])
@@ -251,12 +275,9 @@ def patch_auction_bidder(self):
         response.json['data']['tenderers'][0]['name'],
         bidder['tenderers'][0]['name'])
 
-    response = self.app.patch_json(
-        '/auctions/{}/bids/{}'.format(
-            self.auction_id, bidder['id']), {
-            "data": {
-                "value": {
-                    "amount": 500}, 'tenderers': [test_organization]}})
+    response = self.app.patch_json('/auctions/{}/bids/{}?acc_token={}'.format(
+        self.auction_id, bidder['id'], bid_token
+    ), {"data": {"value": {"amount": 500}, 'tenderers': [test_organization]}})
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['data']['date'], bidder['date'])
@@ -264,32 +285,25 @@ def patch_auction_bidder(self):
         response.json['data']['tenderers'][0]['name'],
         bidder['tenderers'][0]['name'])
 
-    response = self.app.patch_json(
-        '/auctions/{}/bids/{}'.format(
-            self.auction_id, bidder['id']), {
-            "data": {
-                "value": {
-                    "amount": 400}}})
+    response = self.app.patch_json('/auctions/{}/bids/{}?acc_token={}'.format(
+        self.auction_id, bidder['id'], bid_token
+    ), {"data": {"value": {"amount": 400}}})
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['data']["value"]["amount"], 400)
     self.assertNotEqual(response.json['data']['date'], bidder['date'])
 
-    response = self.app.patch_json(
-        '/auctions/{}/bids/{}'.format(
-            self.auction_id, bidder['id']), {
-            "data": {
-                "status": "active"}})
+    response = self.app.patch_json('/auctions/{}/bids/{}?acc_token={}'.format(
+        self.auction_id, bidder['id'], bid_token
+    ), {"data": {"status": "active"}})
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['data']["status"], "active")
     self.assertNotEqual(response.json['data']['date'], bidder['date'])
 
-    response = self.app.patch_json(
-        '/auctions/{}/bids/{}'.format(
-            self.auction_id, bidder['id']), {
-            "data": {
-                "status": "draft"}}, status=403)
+    response = self.app.patch_json('/auctions/{}/bids/{}?acc_token={}'.format(
+        self.auction_id, bidder['id'], bid_token
+    ), {"data": {"status": "draft"}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(
@@ -311,7 +325,10 @@ def patch_auction_bidder(self):
     ])
 
     response = self.app.patch_json(
-        '/auctions/some_id/bids/some_id', {"data": {"value": {"amount": 400}}}, status=404)
+        '/auctions/some_id/bids/some_id',
+        {"data": {"value": {"amount": 400}}},
+        status=404
+    )
     self.assertEqual(response.status, '404 Not Found')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['status'], 'error')
@@ -328,12 +345,9 @@ def patch_auction_bidder(self):
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['data']["value"]["amount"], 400)
 
-    response = self.app.patch_json(
-        '/auctions/{}/bids/{}'.format(
-            self.auction_id, bidder['id']), {
-            "data": {
-                "value": {
-                    "amount": 400}}}, status=403)
+    response = self.app.patch_json('/auctions/{}/bids/{}?acc_token={}'.format(
+        self.auction_id, bidder['id'], bid_token
+    ), {"data": {"value": {"amount": 400}}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(
@@ -354,7 +368,10 @@ def get_auction_bidder(self):
     bid_token = response.json['access']['token']
 
     response = self.app.get(
-        '/auctions/{}/bids/{}'.format(self.auction_id, bidder['id']), status=403)
+        '/auctions/{}/bids/{}'.format(
+            self.auction_id, bidder['id']
+        ), status=403
+    )
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(
@@ -362,7 +379,9 @@ def get_auction_bidder(self):
         "Can't view bid in current (active.tendering) auction status")
 
     response = self.app.get(
-        '/auctions/{}/bids/{}?acc_token={}'.format(self.auction_id, bidder['id'], bid_token))
+        '/auctions/{}/bids/{}?acc_token={}'.format(
+            self.auction_id, bidder['id'], bid_token)
+    )
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['data'], bidder)
@@ -396,7 +415,9 @@ def get_auction_bidder(self):
     ])
 
     response = self.app.delete(
-        '/auctions/{}/bids/{}'.format(self.auction_id, bidder['id']), status=403)
+        '/auctions/{}/bids/{}?acc_token={}'.format(
+        self.auction_id, bidder['id'], bid_token
+    ), status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(
@@ -414,9 +435,12 @@ def delete_auction_bidder(self):
     self.assertEqual(response.status, '201 Created')
     self.assertEqual(response.content_type, 'application/json')
     bidder = response.json['data']
+    bid_token = response.json['access']['token']
 
     response = self.app.delete(
-        '/auctions/{}/bids/{}'.format(self.auction_id, bidder['id']))
+        '/auctions/{}/bids/{}?acc_token={}'.format(
+        self.auction_id, bidder['id'], bid_token
+    ))
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['data'], bidder)
@@ -495,10 +519,13 @@ def bid_Administrator_change(self):
     bidder = response.json['data']
 
     self.app.authorization = ('Basic', ('administrator', ''))
-    response = self.app.patch_json('/auctions/{}/bids/{}'.format(self.auction_id, bidder['id']), {"data": {
-        'tenderers': [{"identifier": {"id": "00000000"}}],
-        "value": {"amount": 400}
-    }})
+    response = self.app.patch_json(
+        '/auctions/{}/bids/{}'.format(
+            self.auction_id, bidder['id']
+        ), {"data": {
+                'tenderers': [{"identifier": {"id": "00000000"}}],
+                "value": {"amount": 400}}}
+    )
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertNotEqual(response.json['data']["value"]["amount"], 400)
@@ -570,11 +597,13 @@ def create_auction_bidder_document_nopending(self):
                 'tenderers': [test_organization], "value": {
                     "amount": 500}}})
     bid = response.json['data']
+    bid_token = response.json['access']['token']
     bid_id = bid['id']
 
     response = self.app.post(
-        '/auctions/{}/bids/{}/documents'.format(
-            self.auction_id, bid_id), upload_files=[
+        '/auctions/{}/bids/{}/documents?acc_token={}'.format(
+            self.auction_id, bid_id, bid_token
+    ), upload_files=[
             ('file', 'name.doc', 'content')])
     self.assertEqual(response.status, '201 Created')
     self.assertEqual(response.content_type, 'application/json')
@@ -584,8 +613,9 @@ def create_auction_bidder_document_nopending(self):
     self.set_status('active.qualification')
 
     response = self.app.patch_json(
-        '/auctions/{}/bids/{}/documents/{}'.format(
-            self.auction_id, bid_id, doc_id), {
+        '/auctions/{}/bids/{}/documents/{}?acc_token={}'.format(
+            self.auction_id, bid_id, doc_id, bid_token
+    ), {
             "data": {
                 "description": "document description"}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
@@ -595,10 +625,11 @@ def create_auction_bidder_document_nopending(self):
         "Can't update document because award of bid is not in pending state")
 
     response = self.app.put(
-        '/auctions/{}/bids/{}/documents/{}'.format(
+        '/auctions/{}/bids/{}/documents/{}?acc_token={}'.format(
             self.auction_id,
             bid_id,
-            doc_id),
+            doc_id, bid_token
+    ),
         'content3',
         content_type='application/msword',
         status=403)
@@ -609,8 +640,9 @@ def create_auction_bidder_document_nopending(self):
         "Can't update document because award of bid is not in pending state")
 
     response = self.app.post(
-        '/auctions/{}/bids/{}/documents'.format(
-            self.auction_id, bid_id), upload_files=[
+        '/auctions/{}/bids/{}/documents?acc_token={}'.format(
+            self.auction_id, bid_id, bid_token
+    ), upload_files=[
             ('file', 'name.doc', 'content')], status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')

--- a/openprocurement/auctions/flash/tests/blanks/contract_blanks.py
+++ b/openprocurement/auctions/flash/tests/blanks/contract_blanks.py
@@ -10,11 +10,7 @@ def patch_auction_contract(self):
     response = self.app.get('/auctions/{}/contracts'.format(self.auction_id))
     contract = response.json['data'][0]
 
-    response = self.app.patch_json(
-        '/auctions/{}/contracts/{}'.format(
-            self.auction_id, contract['id']), {
-            "data": {
-                "status": "active"}}, status=403)
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(self.auction_id, contract['id'], self.auction_token), {"data": {"status": "active"}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertIn(
@@ -23,16 +19,12 @@ def patch_auction_contract(self):
 
     self.set_status('complete', {'status': 'active.awarded'})
 
-    response = self.app.post_json(
-        '/auctions/{}/awards/{}/complaints'.format(
-            self.auction_id,
-            self.award_id),
-        {
-            'data': {
-                'title': 'complaint title',
-                'description': 'complaint description',
-                'author': self.initial_organization,
-                'status': 'claim'}})
+    response = self.app.post_json('/auctions/{}/awards/{}/complaints?acc_token={}'.format(self.auction_id, self.award_id, self.first_bid_token), {'data': {
+        'title': 'complaint title',
+        'description': 'complaint description',
+        'author': self.initial_organization,
+        'status': 'claim'
+    }})
     self.assertEqual(response.status, '201 Created')
     complaint = response.json['data']
     owner_token = response.json['access']['token']
@@ -42,8 +34,10 @@ def patch_auction_contract(self):
         i['complaintPeriod']['endDate'] = i['complaintPeriod']['startDate']
     self.db.save(auction)
 
-    response = self.app.patch_json('/auctions/{}/contracts/{}'.format(self.auction_id,
-                                                                      contract['id']),
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id,
+                                                                      contract['id'], self.auction_token
+    ),
                                    {"data": {"contractID": "myselfID",
                                              "items": [{"description": "New Description"}],
                                              "suppliers": [{"name": "New Name"}]}})
@@ -56,53 +50,29 @@ def patch_auction_contract(self):
     self.assertEqual(response.json['data']['items'], contract['items'])
     self.assertEqual(response.json['data']['suppliers'], contract['suppliers'])
 
-    response = self.app.patch_json(
-        '/auctions/{}/contracts/{}'.format(
-            self.auction_id, contract['id']), {
-            "data": {
-                "value": {
-                    "currency": "USD"}}}, status=403)
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(self.auction_id, contract['id'], self.auction_token), {"data": {"value": {"currency": "USD"}}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(
         response.json['errors'][0]["description"],
         "Can\'t update currency for contract value")
 
-    response = self.app.patch_json(
-        '/auctions/{}/contracts/{}'.format(
-            self.auction_id, contract['id']), {
-            "data": {
-                "value": {
-                    "valueAddedTaxIncluded": False}}}, status=403)
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(self.auction_id, contract['id'], self.auction_token), {"data": {"value": {"valueAddedTaxIncluded": False}}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(
         response.json['errors'][0]["description"],
         "Can\'t update valueAddedTaxIncluded for contract value")
 
-    response = self.app.patch_json(
-        '/auctions/{}/contracts/{}'.format(
-            self.auction_id, contract['id']), {
-            "data": {
-                "value": {
-                    "amount": 99}}}, status=403)
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(self.auction_id, contract['id'], self.auction_token), {"data": {"value": {"amount": 99}}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(
         response.json['errors'][0]["description"],
-        "Value amount should be greater or equal to awarded amount (100.0)")
+        "Value amount should be greater or equal to awarded amount (479.0)")
 
-    response = self.app.patch_json(
-        '/auctions/{}/contracts/{}'.format(
-            self.auction_id, contract['id']), {
-            "data": {
-                "value": {
-                    "amount": 238}}})
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(self.auction_id, contract['id'], self.auction_token), {"data": {"value": {"amount": 500}}})
     self.assertEqual(response.status, '200 OK')
-    self.assertEqual(response.json['data']['value']['amount'], 238)
+    self.assertEqual(response.json['data']['value']['amount'], 500)
 
-    response = self.app.patch_json(
-        '/auctions/{}/contracts/{}'.format(
-            self.auction_id, contract['id']), {
-            "data": {
-                "dateSigned": i['complaintPeriod']['endDate']}}, status=422)
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(self.auction_id, contract['id'], self.auction_token), {"data": {"dateSigned": i['complaintPeriod']['endDate']}}, status=422)
     self.assertEqual(response.status, '422 Unprocessable Entity')
     self.assertEqual(
         response.json['errors'], [
@@ -112,28 +82,16 @@ def patch_auction_contract(self):
                         i['complaintPeriod']['endDate'])], u'location': u'body', u'name': u'dateSigned'}])
 
     one_hour_in_furure = (get_now() + timedelta(hours=1)).isoformat()
-    response = self.app.patch_json(
-        '/auctions/{}/contracts/{}'.format(
-            self.auction_id, contract['id']), {
-            "data": {
-                "dateSigned": one_hour_in_furure}}, status=422)
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(self.auction_id, contract['id'], self.auction_token), {"data": {"dateSigned": one_hour_in_furure}}, status=422)
     self.assertEqual(response.status, '422 Unprocessable Entity')
     self.assertEqual(response.json['errors'], [{u'description': [
                      u"Contract signature date can't be in the future"], u'location': u'body', u'name': u'dateSigned'}])
 
     custom_signature_date = get_now().isoformat()
-    response = self.app.patch_json(
-        '/auctions/{}/contracts/{}'.format(
-            self.auction_id, contract['id']), {
-            "data": {
-                "dateSigned": custom_signature_date}})
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(self.auction_id, contract['id'], self.auction_token), {"data": {"dateSigned": custom_signature_date}})
     self.assertEqual(response.status, '200 OK')
 
-    response = self.app.patch_json(
-        '/auctions/{}/contracts/{}'.format(
-            self.auction_id, contract['id']), {
-            "data": {
-                "status": "active"}}, status=403)
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(self.auction_id, contract['id'], self.auction_token), {"data": {"status": "active"}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(
@@ -162,55 +120,41 @@ def patch_auction_contract(self):
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['data']["status"], "resolved")
 
-    response = self.app.patch_json(
-        '/auctions/{}/contracts/{}'.format(
-            self.auction_id, contract['id']), {
-            "data": {
-                "status": "active"}})
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(self.auction_id, contract['id'], self.auction_token), {"data": {"status": "active"}})
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['data']["status"], "active")
 
-    response = self.app.patch_json(
-        '/auctions/{}/contracts/{}'.format(
-            self.auction_id, contract['id']), {
-            "data": {
-                "value": {
-                    "amount": 232}}}, status=403)
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(self.auction_id, contract['id'], self.auction_token), {"data": {"value": {"amount": 232}}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(
         response.json['errors'][0]["description"],
         "Can't update contract in current (complete) auction status")
 
-    response = self.app.patch_json(
-        '/auctions/{}/contracts/{}'.format(
-            self.auction_id, contract['id']), {
-            "data": {
-                "contractID": "myselfID"}}, status=403)
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(self.auction_id, contract['id'], self.auction_token), {"data": {"contractID": "myselfID"}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(
         response.json['errors'][0]["description"],
         "Can't update contract in current (complete) auction status")
 
-    response = self.app.patch_json('/auctions/{}/contracts/{}'.format(self.auction_id, contract['id']), {
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
+    ), {
                                    "data": {"items": [{"description": "New Description"}]}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(
         response.json['errors'][0]["description"],
         "Can't update contract in current (complete) auction status")
 
-    response = self.app.patch_json('/auctions/{}/contracts/{}'.format(
-        self.auction_id, contract['id']), {"data": {"suppliers": [{"name": "New Name"}]}}, status=403)
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+        self.auction_id, contract['id'], self.auction_token
+    ), {"data": {"suppliers": [{"name": "New Name"}]}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(
         response.json['errors'][0]["description"],
         "Can't update contract in current (complete) auction status")
 
-    response = self.app.patch_json(
-        '/auctions/{}/contracts/{}'.format(
-            self.auction_id, contract['id']), {
-            "data": {
-                "status": "active"}}, status=403)
+    response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(self.auction_id, contract['id'], self.auction_token), {"data": {"status": "active"}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(
@@ -245,7 +189,7 @@ def patch_auction_contract(self):
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['data']["status"], "active")
-    self.assertEqual(response.json['data']["value"]['amount'], 238)
+    self.assertEqual(response.json['data']["value"]['amount'], 500)
     self.assertEqual(
         response.json['data']['contractID'],
         contract['contractID'])

--- a/openprocurement/auctions/flash/tests/blanks/document_blanks.py
+++ b/openprocurement/auctions/flash/tests/blanks/document_blanks.py
@@ -81,9 +81,10 @@ def create_auction_document(self):
     response = self.app.post(
         '/auctions/{}/documents?acc_token={}'.format(
             self.auction_id, self.auction_token
-    ), upload_files=[
-            ('file', u'укр.doc'.encode(
-                "ascii", "xmlcharrefreplace"), 'content')])
+        ), upload_files=[('file', u'укр.doc'.encode(
+            "ascii", "xmlcharrefreplace"
+        ), 'content')]
+    )
     self.assertEqual(response.status, '201 Created')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(u'укр.doc', response.json["data"]["title"])
@@ -96,8 +97,8 @@ def create_auction_document(self):
     response = self.app.post(
         '/auctions/{}/documents?acc_token={}'.format(
             self.auction_id, self.auction_token
-    ), upload_files=[
-            ('file', u'укр.doc', 'content')], status=403)
+        ), upload_files=[('file', u'укр.doc', 'content')], status=403
+    )
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(
@@ -148,8 +149,8 @@ def put_auction_document(self):
     response = self.app.put(
         '/auctions/{}/documents/{}?acc_token={}'.format(
             self.auction_id, doc_id, self.auction_token
-    ), upload_files=[
-            ('file', 'name  name.doc', 'content2')])
+        ), upload_files=[('file', 'name  name.doc', 'content2')]
+    )
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(doc_id, response.json["data"]["id"])
@@ -217,8 +218,11 @@ def put_auction_document(self):
     self.assertEqual(dateModified2, response.json["data"][0]['dateModified'])
     self.assertEqual(dateModified, response.json["data"][1]['dateModified'])
 
-    response = self.app.put('/auctions/{}/documents/{}?acc_token={}'.format(self.auction_id, doc_id, self.auction_token), status=404, upload_files=[
-                            ('invalid_name', 'name.doc', 'content')])
+    response = self.app.put(
+        '/auctions/{}/documents/{}?acc_token={}'.format(
+            self.auction_id, doc_id, self.auction_token
+        ), status=404, upload_files=[('invalid_name', 'name.doc', 'content')]
+    )
     self.assertEqual(response.status, '404 Not Found')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['status'], 'error')
@@ -231,9 +235,8 @@ def put_auction_document(self):
         '/auctions/{}/documents/{}?acc_token={}'.format(
             self.auction_id,
             doc_id, self.auction_token
-    ),
-        'content3',
-        content_type='application/msword')
+        ), 'content3', content_type='application/msword'
+    )
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(doc_id, response.json["data"]["id"])
@@ -271,13 +274,14 @@ def put_auction_document(self):
     response = self.app.put(
         '/auctions/{}/documents/{}?acc_token={}'.format(
             self.auction_id, doc_id, self.auction_token
-    ), upload_files=[
-            ('file', 'name.doc', 'content3')], status=403)
+        ), upload_files=[('file', 'name.doc', 'content3')], status=403
+    )
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(
         response.json['errors'][0]["description"],
-        "Can't update document in current (active.tendering) auction status")
+        "Can't update document in current (active.tendering) auction status"
+    )
 
 
 def patch_auction_document(self):
@@ -291,48 +295,56 @@ def patch_auction_document(self):
     self.assertEqual(u'укр.doc', response.json["data"]["title"])
     self.assertNotIn("documentType", response.json["data"])
 
-    response = self.app.patch_json('/auctions/{}/documents/{}?acc_token={}'.format(self.auction_id, doc_id, self.auction_token), {"data": {
-        "documentOf": "lot"
-    }}, status=422)
+    response = self.app.patch_json(
+        '/auctions/{}/documents/{}?acc_token={}'.format(
+            self.auction_id, doc_id, self.auction_token
+        ), {"data": {"documentOf": "lot"}}, status=422
+    )
     self.assertEqual(response.status, '422 Unprocessable Entity')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['status'], 'error')
     self.assertEqual(response.json['errors'], [{u'description': [
                      u'This field is required.'], u'location': u'body', u'name': u'relatedItem'}, ])
 
-    response = self.app.patch_json('/auctions/{}/documents/{}?acc_token={}'.format(self.auction_id, doc_id, self.auction_token), {"data": {
-        "documentOf": "lot",
-        "relatedItem": '0' * 32
-    }}, status=422)
+    response = self.app.patch_json(
+        '/auctions/{}/documents/{}?acc_token={}'.format(
+            self.auction_id, doc_id, self.auction_token
+        ), {"data": {"documentOf": "lot", "relatedItem": '0' * 32}}, status=422
+    )
     self.assertEqual(response.status, '422 Unprocessable Entity')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['status'], 'error')
     self.assertEqual(response.json['errors'], [{u'description': [
                      u'relatedItem should be one of lots'], u'location': u'body', u'name': u'relatedItem'}])
 
-    response = self.app.patch_json('/auctions/{}/documents/{}?acc_token={}'.format(self.auction_id, doc_id, self.auction_token), {"data": {
-        "documentOf": "item",
-        "relatedItem": '0' * 32
-    }}, status=422)
+    response = self.app.patch_json(
+        '/auctions/{}/documents/{}?acc_token={}'.format(
+            self.auction_id, doc_id, self.auction_token
+        ), {"data": {"documentOf": "item", "relatedItem": '0' * 32}}, status=422
+    )
     self.assertEqual(response.status, '422 Unprocessable Entity')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['status'], 'error')
     self.assertEqual(response.json['errors'], [{u'description': [
                      u'relatedItem should be one of items'], u'location': u'body', u'name': u'relatedItem'}])
 
-    response = self.app.patch_json('/auctions/{}/documents/{}?acc_token={}'.format(self.auction_id, doc_id, self.auction_token), {"data": {
-        "description": "document description",
-        "documentType": 'auctionNotice'
-    }})
+    response = self.app.patch_json(
+        '/auctions/{}/documents/{}?acc_token={}'.format(
+            self.auction_id, doc_id, self.auction_token
+        ), {"data": {"description": "document description",
+                     "documentType": 'auctionNotice'}}
+    )
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(doc_id, response.json["data"]["id"])
     self.assertIn("documentType", response.json["data"])
     self.assertEqual(response.json["data"]["documentType"], 'auctionNotice')
 
-    response = self.app.patch_json('/auctions/{}/documents/{}?acc_token={}'.format(self.auction_id, doc_id, self.auction_token), {"data": {
-        "documentType": None
-    }})
+    response = self.app.patch_json(
+        '/auctions/{}/documents/{}?acc_token={}'.format(
+            self.auction_id, doc_id, self.auction_token
+        ), {"data": {"documentType": None}}
+    )
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(doc_id, response.json["data"]["id"])
@@ -349,12 +361,17 @@ def patch_auction_document(self):
 
     self.set_status('active.tendering')
 
-    response = self.app.patch_json('/auctions/{}/documents/{}?acc_token={}'.format(self.auction_id, doc_id, self.auction_token), {"data": {"description": "document description"}}, status=403)
+    response = self.app.patch_json(
+        '/auctions/{}/documents/{}?acc_token={}'.format(
+            self.auction_id, doc_id, self.auction_token
+        ), {"data": {"description": "document description"}}, status=403
+    )
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(
         response.json['errors'][0]["description"],
-        "Can't update document in current (active.tendering) auction status")
+        "Can't update document in current (active.tendering) auction status"
+    )
 
 # AuctionDocumentWithDSResourceTest
 
@@ -450,13 +467,14 @@ def put_auction_document_json(self):
     datePublished = response.json["data"]['datePublished']
     self.assertIn(doc_id, response.headers['Location'])
 
-    response = self.app.put_json('/auctions/{}/documents/{}?acc_token={}'.format(self.auction_id, doc_id, self.auction_token),{
-        'data': {
-            'title': u'name.doc',
-            'url': self.generate_docservice_url(),
-            'hash': 'md5:' + '0' * 32,
-            'format': 'application/msword',
-        }})
+    response = self.app.put_json(
+        '/auctions/{}/documents/{}?acc_token={}'.format(
+            self.auction_id, doc_id, self.auction_token
+        ), {'data': {'title': u'name.doc',
+                     'url': self.generate_docservice_url(),
+                     'hash': 'md5:' + '0' * 32,
+                     'format': 'application/msword'}}
+    )
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(doc_id, response.json["data"]["id"])
@@ -498,13 +516,14 @@ def put_auction_document_json(self):
     self.assertEqual(dateModified, response.json["data"][0]['dateModified'])
     self.assertEqual(dateModified2, response.json["data"][1]['dateModified'])
 
-    response = self.app.post_json('/auctions/{}/documents?acc_token={}'.format(self.auction_id, self.auction_token),{
-        'data': {
-            'title': 'name.doc',
-            'url': self.generate_docservice_url(),
-            'hash': 'md5:' + '0' * 32,
-            'format': 'application/msword',
-        }})
+    response = self.app.post_json(
+        '/auctions/{}/documents?acc_token={}'.format(
+            self.auction_id, self.auction_token
+        ), {'data': {'title': 'name.doc',
+                     'url': self.generate_docservice_url(),
+                     'hash': 'md5:' + '0' * 32,
+                     'format': 'application/msword'}}
+    )
     self.assertEqual(response.status, '201 Created')
     self.assertEqual(response.content_type, 'application/json')
     doc_id = response.json["data"]['id']
@@ -517,13 +536,15 @@ def put_auction_document_json(self):
     self.assertEqual(dateModified2, response.json["data"][0]['dateModified'])
     self.assertEqual(dateModified, response.json["data"][1]['dateModified'])
 
-    response = self.app.put_json('/auctions/{}/documents/{}?acc_token={}'.format(self.auction_id, doc_id, self.auction_token),{
-        'data': {
-            'title': u'укр.doc',
-            'url': self.generate_docservice_url(),
-            'hash': 'md5:' + '0' * 32,
-            'format': 'application/msword',
-        }})
+    response = self.app.put_json(
+        '/auctions/{}/documents/{}?acc_token={}'.format(
+            self.auction_id, doc_id, self.auction_token
+        ), {'data': {'title': u'укр.doc',
+                     'url': self.generate_docservice_url(),
+                     'hash': 'md5:' + '0' * 32,
+                     'format': 'application/msword'}
+            }
+    )
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(doc_id, response.json["data"]["id"])
@@ -547,15 +568,18 @@ def put_auction_document_json(self):
 
     self.set_status('active.tendering')
 
-    response = self.app.put_json('/auctions/{}/documents/{}?acc_token={}'.format(self.auction_id, doc_id, self.auction_token),
-        {'data': {
-            'title': u'укр.doc',
-            'url': self.generate_docservice_url(),
-            'hash': 'md5:' + '0' * 32,
-            'format': 'application/msword',}},
-         status=403)
+    response = self.app.put_json(
+        '/auctions/{}/documents/{}?acc_token={}'.format(
+            self.auction_id, doc_id, self.auction_token
+        ), {'data': {'title': u'укр.doc',
+                     'url': self.generate_docservice_url(),
+                     'hash': 'md5:' + '0' * 32,
+                     'format': 'application/msword'}
+            }, status=403
+    )
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(
         response.json['errors'][0]["description"],
-        "Can't update document in current (active.tendering) auction status")
+        "Can't update document in current (active.tendering) auction status"
+    )

--- a/openprocurement/auctions/flash/tests/blanks/tender_blanks.py
+++ b/openprocurement/auctions/flash/tests/blanks/tender_blanks.py
@@ -80,8 +80,10 @@ def edit_role(self):
                   ])
     if SANDBOX_MODE:
         fields.add('procurementMethodDetails')
-    self.assertEqual(set(Auction._fields) -
-                     Auction._options.roles['edit_active.enquiries'].fields, fields)
+    self.assertEqual(
+        set(Auction._fields) - Auction._options.roles['edit_active.enquiries'].fields,
+        fields
+    )
 
 # AuctionResourceTest
 
@@ -530,18 +532,18 @@ def patch_auction(self):
 
     response = self.app.patch_json(
         '/auctions/{}?acc_token={}'.format(
-        auction['id'], owner_token
-    ), {'data': {'status': 'cancelled'}})
+            auction['id'], owner_token
+        ), {'data': {'status': 'cancelled'}}
+    )
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertNotEqual(response.json['data']['status'], 'cancelled')
 
     response = self.app.patch_json(
         '/auctions/{}?acc_token={}'.format(
-            auction['id'], owner_token), {
-            'data': {
-                'procuringEntity': {
-                    'kind': 'defense'}}})
+            auction['id'], owner_token
+        ), {'data': {'procuringEntity': {'kind': 'defense'}}}
+    )
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertNotIn('kind', response.json['data']['procuringEntity'])
@@ -556,10 +558,12 @@ def patch_auction(self):
     response = self.app.patch_json(
         '/auctions/{}?acc_token={}'.format(
             auction['id'], owner_token
-    ), {
-            'data': {
+        ), {'data': {
                 'tenderPeriod': {
-                    'startDate': auction['enquiryPeriod']['endDate']}}})
+                    'startDate': auction['enquiryPeriod']['endDate']
+                }
+        }}
+    )
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertIn('startDate', response.json['data']['tenderPeriod'])
@@ -599,10 +603,8 @@ def patch_auction(self):
     response = self.app.patch_json(
         '/auctions/{}?acc_token={}'.format(
             auction['id'], owner_token
-    ), {
-            'data': {
-                'items': [
-                    {}, test_auction_data['items'][0]]}})
+        ), {'data': {'items': [{}, test_auction_data['items'][0]]}}
+    )
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     item0 = response.json['data']['items'][0]
@@ -617,11 +619,20 @@ def patch_auction(self):
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(len(response.json['data']['items']), 1)
 
-    response = self.app.patch_json('/auctions/{}?acc_token={}'.format(auction['id'], owner_token), {'data': {'items': [{"classification": {
-        "scheme": u"CAV",
-        "id": u"70123000-9",
-        "description": u"Нерухомість"
-    }}]}})
+    response = self.app.patch_json(
+        '/auctions/{}?acc_token={}'.format(
+            auction['id'], owner_token
+        ), {'data': {
+            'items': [
+                {
+                    "classification": {"scheme": u"CAV",
+                                       "id": u"70123000-9",
+                                       "description": u"Нерухомість"}
+                }
+
+            ]
+        }}
+    )
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
 
@@ -635,10 +646,9 @@ def patch_auction(self):
     response = self.app.patch_json(
         '/auctions/{}?acc_token={}'.format(
             auction['id'], owner_token
-    ), {
-            'data': {
-                'enquiryPeriod': {
-                    'endDate': new_dateModified2}}})
+        ), {'data': {'enquiryPeriod': {
+                     'endDate': new_dateModified2}}}
+    )
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     new_auction = response.json['data']
@@ -682,8 +692,9 @@ def patch_auction(self):
 
     response = self.app.patch_json(
         '/auctions/{}?acc_token={}'.format(
-        auction['id'], owner_token
-    ), {'data': {'status': 'active.auction'}}, status=403)
+            auction['id'], owner_token
+        ), {'data': {'status': 'active.auction'}}, status=403
+    )
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(
@@ -748,8 +759,9 @@ def guarantee(self):
 
     response = self.app.patch_json(
         '/auctions/{}?acc_token={}'.format(
-        auction['id'], owner_token
-    ), {'data': {'guarantee': None}})
+            auction['id'], owner_token
+        ), {'data': {'guarantee': None}}
+    )
     self.assertEqual(response.status, '200 OK')
     self.assertIn('guarantee', response.json['data'])
     self.assertEqual(response.json['data']['guarantee']['amount'], 100500)
@@ -787,6 +799,8 @@ def one_valid_bid_auction(self):
             'data': {
                 'tenderers': [test_organization], "value": {
                     "amount": 500}}})
+    self.assertEqual(response.status, '201 Created')
+
     # switch to active.qualification
     self.set_status('active.auction', {'status': 'active.tendering'})
     self.app.authorization = ('Basic', ('chronograph', ''))
@@ -813,7 +827,7 @@ def one_valid_bid_auction(self):
     # get contract id
     response = self.app.get('/auctions/{}'.format(auction_id))
     contract_id = response.json['data']['contracts'][-1]['id']
-    # after stand slill period
+    # after stand still period
     self.app.authorization = ('Basic', ('chronograph', ''))
     self.set_status('complete', {'status': 'active.awarded'})
     # time travel
@@ -850,6 +864,7 @@ def one_invalid_bid_auction(self):
             'data': {
                 'tenderers': [test_organization], "value": {
                     "amount": 500}}})
+    self.assertEqual(response.status, '201 Created')
     # switch to active.qualification
     self.set_status(
         'active.auction', {
@@ -858,6 +873,7 @@ def one_invalid_bid_auction(self):
     self.app.authorization = ('Basic', ('chronograph', ''))
     response = self.app.patch_json(
         '/auctions/{}'.format(auction_id), {"data": {"id": auction_id}})
+    self.assertEqual(response.status, '200 OK')
     # get awards
     self.app.authorization = ('Basic', ('broker', ''))
     response = self.app.get(
@@ -867,16 +883,20 @@ def one_invalid_bid_auction(self):
                 for i in response.json['data'] if i['status'] == 'pending'][0]
     # set award as unsuccessful
     response = self.app.patch_json('/auctions/{}/awards/{}?acc_token={}'.format(
-        auction_id, award_id, owner_token), {"data": {"status": "unsuccessful"}})
+        auction_id, award_id, owner_token
+    ), {"data": {"status": "unsuccessful"}})
+    self.assertEqual(response.status, '200 OK')
     # time travel
     auction = self.db.get(auction_id)
     for i in auction.get('awards', []):
         i['complaintPeriod']['endDate'] = i['complaintPeriod']['startDate']
     self.db.save(auction)
-    # set auction status after stand slill period
+    # set auction status after stand still period
     self.app.authorization = ('Basic', ('chronograph', ''))
     response = self.app.patch_json(
-        '/auctions/{}'.format(auction_id), {"data": {"id": auction_id}})
+        '/auctions/{}'.format(auction_id), {"data": {"id": auction_id}}
+    )
+    self.assertEqual(response.status, '200 OK')
     # check status
     self.app.authorization = ('Basic', ('broker', ''))
     response = self.app.get('/auctions/{}'.format(auction_id))
@@ -910,7 +930,9 @@ def first_bid_auction(self):
         '/auctions/{}/bids'.format(auction_id), {
             'data': {
                 'tenderers': [test_organization], "value": {
-                    "amount": 475}}})
+                    "amount": 475}}}
+    )
+    self.assertEqual(response.status, '201 Created')
     # switch to active.auction
     self.set_status('active.auction')
 
@@ -929,6 +951,7 @@ def first_bid_auction(self):
                         'id': i['id'],
                         'participationUrl': 'https://auction.auction.url/for_bid/{}'.format(
                             i['id'])} for i in auction_bids_data]}})
+    self.assertEqual(response.status, '200 OK')
     # view bid participationUrl
     self.app.authorization = ('Basic', ('broker', ''))
     response = self.app.get(
@@ -941,6 +964,7 @@ def first_bid_auction(self):
     self.app.authorization = ('Basic', ('auction', ''))
     response = self.app.post_json('/auctions/{}/auction'.format(auction_id),
                                   {'data': {'bids': auction_bids_data}})
+    self.assertEqual(response.status, '200 OK')
     # get awards
     self.app.authorization = ('Basic', ('broker', ''))
     response = self.app.get(
@@ -950,7 +974,9 @@ def first_bid_auction(self):
                 for i in response.json['data'] if i['status'] == 'pending'][0]
     # set award as unsuccessful
     response = self.app.patch_json('/auctions/{}/awards/{}?acc_token={}'.format(
-        auction_id, award_id, owner_token), {"data": {"status": "unsuccessful"}})
+        auction_id, award_id, owner_token
+    ), {"data": {"status": "unsuccessful"}})
+    self.assertEqual(response.status, '200 OK')
     # get awards
     self.app.authorization = ('Basic', ('broker', ''))
     response = self.app.get(
@@ -984,7 +1010,9 @@ def first_bid_auction(self):
             'data': {
                 'title': 'complaint title',
                 'description': 'complaint description',
-                'author': test_organization}})
+                'author': test_organization}}
+    )
+    self.assertEqual(response.status, '201 Created')
     # answering claim
     self.app.patch_json(
         '/auctions/{}/awards/{}/complaints/{}?acc_token={}'.format(

--- a/openprocurement/auctions/flash/tests/blanks/tender_blanks.py
+++ b/openprocurement/auctions/flash/tests/blanks/tender_blanks.py
@@ -529,7 +529,9 @@ def patch_auction(self):
     self.assertNotEqual(response.json['data']['status'], 'cancelled')
 
     response = self.app.patch_json(
-        '/auctions/{}'.format(auction['id']), {'data': {'status': 'cancelled'}})
+        '/auctions/{}?acc_token={}'.format(
+        auction['id'], owner_token
+    ), {'data': {'status': 'cancelled'}})
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertNotEqual(response.json['data']['status'], 'cancelled')
@@ -544,15 +546,17 @@ def patch_auction(self):
     self.assertEqual(response.content_type, 'application/json')
     self.assertNotIn('kind', response.json['data']['procuringEntity'])
 
-    response = self.app.patch_json('/auctions/{}'.format(
-        auction['id']), {'data': {'tenderPeriod': {'startDate': None}}})
+    response = self.app.patch_json('/auctions/{}?acc_token={}'.format(
+        auction['id'], owner_token
+    ), {'data': {'tenderPeriod': {'startDate': None}}})
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertNotIn('startDate', response.json['data']['tenderPeriod'])
 
     response = self.app.patch_json(
-        '/auctions/{}'.format(
-            auction['id']), {
+        '/auctions/{}?acc_token={}'.format(
+            auction['id'], owner_token
+    ), {
             'data': {
                 'tenderPeriod': {
                     'startDate': auction['enquiryPeriod']['endDate']}}})
@@ -560,8 +564,9 @@ def patch_auction(self):
     self.assertEqual(response.content_type, 'application/json')
     self.assertIn('startDate', response.json['data']['tenderPeriod'])
 
-    response = self.app.patch_json('/auctions/{}'.format(
-        auction['id']), {'data': {'procurementMethodRationale': 'Open'}})
+    response = self.app.patch_json('/auctions/{}?acc_token={}'.format(
+        auction['id'], owner_token
+    ), {'data': {'procurementMethodRationale': 'Open'}})
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     new_auction = response.json['data']
@@ -570,8 +575,9 @@ def patch_auction(self):
     self.assertEqual(auction, new_auction)
     self.assertNotEqual(dateModified, new_dateModified)
 
-    response = self.app.patch_json('/auctions/{}'.format(
-        auction['id']), {'data': {'dateModified': new_dateModified}})
+    response = self.app.patch_json('/auctions/{}?acc_token={}'.format(
+        auction['id'], owner_token
+    ), {'data': {'dateModified': new_dateModified}})
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     new_auction2 = response.json['data']
@@ -584,14 +590,16 @@ def patch_auction(self):
     self.assertEqual(revisions[-1][u'changes'][0]
                      ['path'], u'/procurementMethodRationale')
 
-    response = self.app.patch_json('/auctions/{}'.format(
-        auction['id']), {'data': {'items': [test_auction_data['items'][0]]}})
+    response = self.app.patch_json('/auctions/{}?acc_token={}'.format(
+        auction['id'], owner_token
+    ), {'data': {'items': [test_auction_data['items'][0]]}})
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
 
     response = self.app.patch_json(
-        '/auctions/{}'.format(
-            auction['id']), {
+        '/auctions/{}?acc_token={}'.format(
+            auction['id'], owner_token
+    ), {
             'data': {
                 'items': [
                     {}, test_auction_data['items'][0]]}})
@@ -602,31 +610,32 @@ def patch_auction(self):
     self.assertNotEqual(item0.pop('id'), item1.pop('id'))
     self.assertEqual(item0, item1)
 
-    response = self.app.patch_json('/auctions/{}'.format(
-        auction['id']), {'data': {'items': [{}]}})
+    response = self.app.patch_json('/auctions/{}?acc_token={}'.format(
+        auction['id'], owner_token
+    ), {'data': {'items': [{}]}})
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(len(response.json['data']['items']), 1)
 
-    response = self.app.patch_json(
-        '/auctions/{}'.format(
-            auction['id']), {
-            'data': {
-                'items': [
-                    {
-                        "classification": {
-                            "scheme": u"CAV", "id": u"70123000-9", "description": u"Нерухомість"}}]}})
+    response = self.app.patch_json('/auctions/{}?acc_token={}'.format(auction['id'], owner_token), {'data': {'items': [{"classification": {
+        "scheme": u"CAV",
+        "id": u"70123000-9",
+        "description": u"Нерухомість"
+    }}]}})
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
 
-    response = self.app.patch_json('/auctions/{}'.format(auction['id']), {'data': {'items': [
+    response = self.app.patch_json('/auctions/{}?acc_token={}'.format(
+        auction['id'], owner_token
+    ), {'data': {'items': [
                                    {"additionalClassifications": auction['items'][0]["additionalClassifications"]}]}})
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
 
     response = self.app.patch_json(
-        '/auctions/{}'.format(
-            auction['id']), {
+        '/auctions/{}?acc_token={}'.format(
+            auction['id'], owner_token
+    ), {
             'data': {
                 'enquiryPeriod': {
                     'endDate': new_dateModified2}}})
@@ -672,7 +681,9 @@ def patch_auction(self):
     self.db.save(auction_data)
 
     response = self.app.patch_json(
-        '/auctions/{}'.format(auction['id']), {'data': {'status': 'active.auction'}}, status=403)
+        '/auctions/{}?acc_token={}'.format(
+        auction['id'], owner_token
+    ), {'data': {'status': 'active.auction'}}, status=403)
     self.assertEqual(response.status, '403 Forbidden')
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(
@@ -688,6 +699,7 @@ def dateModified_auction(self):
     response = self.app.post_json('/auctions', {'data': self.initial_data})
     self.assertEqual(response.status, '201 Created')
     auction = response.json['data']
+    owner_token = response.json['access']['token']
     dateModified = auction['dateModified']
 
     response = self.app.get('/auctions/{}'.format(auction['id']))
@@ -695,8 +707,9 @@ def dateModified_auction(self):
     self.assertEqual(response.content_type, 'application/json')
     self.assertEqual(response.json['data']['dateModified'], dateModified)
 
-    response = self.app.patch_json('/auctions/{}'.format(
-        auction['id']), {'data': {'procurementMethodRationale': 'Open'}})
+    response = self.app.patch_json('/auctions/{}?acc_token={}'.format(
+        auction['id'], owner_token
+    ), {'data': {'procurementMethodRationale': 'Open'}})
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')
     self.assertNotEqual(response.json['data']['dateModified'], dateModified)
@@ -715,26 +728,28 @@ def guarantee(self):
     self.assertEqual(response.status, '201 Created')
     self.assertNotIn('guarantee', response.json['data'])
     auction = response.json['data']
-    response = self.app.patch_json('/auctions/{}'.format(auction['id']),
-                                   {'data': {'guarantee': {"amount": 55}}})
+    owner_token = response.json['access']['token']
+
+    response = self.app.patch_json('/auctions/{}?acc_token={}'.format(
+        auction['id'], owner_token
+    ), {'data': {'guarantee': {"amount": 55}}})
     self.assertEqual(response.status, '200 OK')
     self.assertIn('guarantee', response.json['data'])
     self.assertEqual(response.json['data']['guarantee']['amount'], 55)
     self.assertEqual(response.json['data']['guarantee']['currency'], 'UAH')
 
-    response = self.app.patch_json(
-        '/auctions/{}'.format(
-            auction['id']), {
-            'data': {
-                'guarantee': {
-                    "amount": 100500, "currency": "USD"}}})
+    response = self.app.patch_json('/auctions/{}?acc_token={}'.format(
+        auction['id'], owner_token
+    ), {'data': {'guarantee': {"amount": 100500, "currency": "USD"}}})
     self.assertEqual(response.status, '200 OK')
     self.assertIn('guarantee', response.json['data'])
     self.assertEqual(response.json['data']['guarantee']['amount'], 100500)
     self.assertEqual(response.json['data']['guarantee']['currency'], 'USD')
 
     response = self.app.patch_json(
-        '/auctions/{}'.format(auction['id']), {'data': {'guarantee': None}})
+        '/auctions/{}?acc_token={}'.format(
+        auction['id'], owner_token
+    ), {'data': {'guarantee': None}})
     self.assertEqual(response.status, '200 OK')
     self.assertIn('guarantee', response.json['data'])
     self.assertEqual(response.json['data']['guarantee']['amount'], 100500)

--- a/openprocurement/auctions/flash/tests/cancellation.py
+++ b/openprocurement/auctions/flash/tests/cancellation.py
@@ -38,8 +38,9 @@ class AuctionCancellationDocumentResourceTest(BaseAuctionWebTest,
     def setUp(self):
         super(AuctionCancellationDocumentResourceTest, self).setUp()
         # Create cancellation
-        response = self.app.post_json('/auctions/{}/cancellations'.format(
-            self.auction_id), {'data': {'reason': 'cancellation reason'}})
+        response = self.app.post_json('/auctions/{}/cancellations?acc_token={}'.format(
+            self.auction_id, self.auction_token
+        ), {'data': {'reason': 'cancellation reason'}})
         cancellation = response.json['data']
         self.cancellation_id = cancellation['id']
 

--- a/openprocurement/auctions/flash/tests/chronograph.py
+++ b/openprocurement/auctions/flash/tests/chronograph.py
@@ -3,9 +3,6 @@ import unittest
 
 from openprocurement.auctions.core.tests.base import snitch
 
-from openprocurement.auctions.flash.tests.base import (
-    BaseAuctionWebTest, test_lots, test_bids, test_organization
-)
 from openprocurement.auctions.core.tests.blanks.chronograph_blanks import (
     # AuctionSwitchAuctionResourceTest
     switch_to_auction,
@@ -17,6 +14,11 @@ from openprocurement.auctions.core.tests.blanks.chronograph_blanks import (
     # AuctionAwardComplaintSwitchResourceTest
     switch_to_pending_award,
     switch_to_complaint_award,
+)
+
+from openprocurement.auctions.flash.tests import fixtures
+from openprocurement.auctions.flash.tests.base import (
+    BaseAuctionWebTest, test_lots, test_bids, test_organization
 )
 from openprocurement.auctions.flash.tests.blanks.chronograph_blanks import (
     # AuctionSwitchtenderingResourceTest
@@ -57,7 +59,9 @@ class AuctionSwitchUnsuccessfulResourceTest(BaseAuctionWebTest):
     test_switch_to_unsuccessful = snitch(switch_to_unsuccessful)
 
 
-class AuctionLotSwitchQualificationResourceTest(AuctionSwitchQualificationResourceTest):
+class AuctionLotSwitchQualificationResourceTest(
+    AuctionSwitchQualificationResourceTest
+):
     initial_lots = test_lots
 
 
@@ -65,7 +69,9 @@ class AuctionLotSwitchAuctionResourceTest(AuctionSwitchAuctionResourceTest):
     initial_lots = test_lots
 
 
-class AuctionLotSwitchUnsuccessfulResourceTest(AuctionSwitchUnsuccessfulResourceTest):
+class AuctionLotSwitchUnsuccessfulResourceTest(
+    AuctionSwitchUnsuccessfulResourceTest
+):
     initial_lots = test_lots
 
 
@@ -86,45 +92,40 @@ class AuctionComplaintSwitchResourceTest(BaseAuctionWebTest):
     test_switch_to_complaint = snitch(switch_to_complaint)
 
 
-class AuctionLotComplaintSwitchResourceTest(AuctionComplaintSwitchResourceTest):
+class AuctionLotComplaintSwitchResourceTest(
+    AuctionComplaintSwitchResourceTest
+):
     initial_lots = test_lots
 
 
 class AuctionAwardComplaintSwitchResourceTest(BaseAuctionWebTest):
-    initial_status = 'active.qualification'
+    initial_status = 'active.auction'
     initial_bids = test_bids
     initial_organization = test_organization
 
     def setUp(self):
         super(AuctionAwardComplaintSwitchResourceTest, self).setUp()
         # Create award
-        response = self.app.post_json(
-            '/auctions/{}/awards'.format(
-                self.auction_id
-            ),
-            {'data': {'suppliers': [test_organization], 'status': 'pending', 'bid_id': self.initial_bids[0]['id']}}
-        )
-        award = response.json['data']
-        self.award_id = award['id']
+        fixtures.create_award(self)
 
-    test_auction_award_complaint_switch_to_pending = snitch(switch_to_pending_award)
-    test_auction_award_complaint_switch_to_complaint = snitch(switch_to_complaint_award)
+    test_auction_award_complaint_switch_to_pending = snitch(
+        switch_to_pending_award
+    )
+    test_auction_award_complaint_switch_to_complaint = snitch(
+        switch_to_complaint_award
+    )
 
 
-class AuctionLotAwardComplaintSwitchResourceTest(AuctionAwardComplaintSwitchResourceTest):
+class AuctionLotAwardComplaintSwitchResourceTest(
+    AuctionAwardComplaintSwitchResourceTest
+):
+    initial_status = 'active.auction'
     initial_lots = test_lots
 
     def setUp(self):
         super(AuctionAwardComplaintSwitchResourceTest, self).setUp()
         # Create award
-        response = self.app.post_json('/auctions/{}/awards'.format(self.auction_id), {'data': {
-            'suppliers': [test_organization],
-            'status': 'pending',
-            'bid_id': self.initial_bids[0]['id'],
-            'lotID': self.initial_bids[0]['lotValues'][0]['relatedLot']
-        }})
-        award = response.json['data']
-        self.award_id = award['id']
+        fixtures.create_award(self)
 
 
 def suite():
@@ -133,7 +134,9 @@ def suite():
     tests.addTest(unittest.makeSuite(AuctionSwitchQualificationResourceTest))
     tests.addTest(unittest.makeSuite(AuctionSwitchAuctionResourceTest))
     tests.addTest(unittest.makeSuite(AuctionSwitchUnsuccessfulResourceTest))
-    tests.addTest(unittest.makeSuite(AuctionLotSwitchQualificationResourceTest))
+    tests.addTest(unittest.makeSuite(
+        AuctionLotSwitchQualificationResourceTest
+    ))
     tests.addTest(unittest.makeSuite(AuctionLotSwitchAuctionResourceTest))
     tests.addTest(unittest.makeSuite(AuctionLotSwitchUnsuccessfulResourceTest))
     tests.addTest(unittest.makeSuite(AuctionAuctionPeriodResourceTest))
@@ -141,7 +144,9 @@ def suite():
     tests.addTest(unittest.makeSuite(AuctionComplaintSwitchResourceTest))
     tests.addTest(unittest.makeSuite(AuctionLotComplaintSwitchResourceTest))
     tests.addTest(unittest.makeSuite(AuctionAwardComplaintSwitchResourceTest))
-    tests.addTest(unittest.makeSuite(AuctionLotAwardComplaintSwitchResourceTest))
+    tests.addTest(unittest.makeSuite(
+        AuctionLotAwardComplaintSwitchResourceTest
+    ))
     return tests
 
 

--- a/openprocurement/auctions/flash/tests/contract.py
+++ b/openprocurement/auctions/flash/tests/contract.py
@@ -2,13 +2,6 @@
 import unittest
 
 from openprocurement.auctions.core.tests.base import snitch
-
-from openprocurement.auctions.flash.tests.base import (
-    BaseAuctionWebTest,
-    test_auction_data,
-    test_bids,
-    test_lots,
-    test_organization)
 from openprocurement.auctions.core.tests.contract import (
     AuctionContractResourceTestMixin,
     AuctionContractDocumentResourceTestMixin,
@@ -23,7 +16,17 @@ from openprocurement.auctions.flash.tests.blanks.contract_blanks import (
     patch_auction_contract,
 )
 from openprocurement.auctions.core.plugins.contracting.v1.tests.contract import (
-    AuctionContractV1ResourceTestCaseMixin)
+    AuctionContractV1ResourceTestCaseMixin
+)
+
+from openprocurement.auctions.flash.tests import fixtures
+from openprocurement.auctions.flash.tests.base import (
+    BaseAuctionWebTest,
+    test_auction_data,
+    test_bids,
+    test_lots,
+    test_organization
+)
 
 
 class AuctionContractResourceTest(
@@ -31,57 +34,54 @@ class AuctionContractResourceTest(
     AuctionContractResourceTestMixin,
     AuctionContractV1ResourceTestCaseMixin
 ):
-    initial_status = 'active.qualification'
+    initial_status = 'active.auction'
     initial_bids = test_bids
     initial_organization = test_organization
 
     def setUp(self):
         super(AuctionContractResourceTest, self).setUp()
         # Create award
-        response = self.app.post_json(
-            '/auctions/{}/awards'.format(self.auction_id),
-            {'data':
-                {
-                    'suppliers': [test_organization],
-                    'status': 'pending',
-                    'bid_id': self.initial_bids[0]['id'],
-                    'value': test_auction_data["value"],
-                    'items': test_auction_data["items"]
-                }
-             }
+        fixtures.create_award(self)
+        # Create contract for award
+        self.app.patch_json('/auctions/{}/awards/{}?acc_token={}'.format(
+            self.auction_id,
+            self.award_id,
+            self.auction_token
+        ), {"data": {"status": "active"}}
         )
-        award = response.json['data']
-        self.award_id = award['id']
-        self.award_value = award['value']
-        self.award_suppliers = award['suppliers']
-        self.award_items = award['items']
-        response = self.app.patch_json(
-            '/auctions/{}/awards/{}'.format(
-                self.auction_id, self.award_id), {
-                "data": {
-                    "status": "active"}})
+        response = self.app.get(
+            '/auctions/{}/contracts'.format(
+                self.auction_id
+            )
+        )
+        self.contract = response.json['data'][0]
+        self.contract_id = self.contract['id']
 
     test_patch_auction_contract = snitch(patch_auction_contract)
 
 
 class Auction2LotContractResourceTest(BaseAuctionWebTest):
-    initial_status = 'active.qualification'
+    initial_status = 'active.auction'
     initial_bids = test_bids
     initial_lots = 2 * test_lots
 
     def setUp(self):
         super(Auction2LotContractResourceTest, self).setUp()
         # Create award
-        response = self.app.post_json('/auctions/{}/awards'.format(self.auction_id), {'data': {
-            'suppliers': [test_organization],
-            'status': 'pending',
-            'bid_id': self.initial_bids[0]['id'],
-            'lotID': self.initial_lots[0]['id']
-        }})
-        award = response.json['data']
-        self.award_id = award['id']
-        self.app.patch_json('/auctions/{}/awards/{}'.format(self.auction_id,
-                                                            self.award_id), {"data": {"status": "active"}})
+        fixtures.create_award(self)
+        # Create contract for award
+        self.app.patch_json(
+            '/auctions/{}/awards/{}?acc_token={}'.format(
+                self.auction_id,
+                self.award_id,
+                self.auction_token
+            ),
+            {"data": {"status": "active"}})
+        response = self.app.get(
+            '/auctions/{}/contracts'.format(self.auction_id)
+        )
+        self.contract = response.json['data'][0]
+        self.contract_id = self.contract['id']
 
     test_patch_auction_lots_contract = snitch(patch_auction_contract_2_lots)
 
@@ -89,63 +89,52 @@ class Auction2LotContractResourceTest(BaseAuctionWebTest):
 class AuctionContractDocumentResourceTest(
         BaseAuctionWebTest,
         AuctionContractDocumentResourceTestMixin):
-    initial_status = 'active.qualification'
+    initial_status = 'active.auction'
     initial_bids = test_bids
     docservice = True
 
     def setUp(self):
         super(AuctionContractDocumentResourceTest, self).setUp()
         # Create award
-        response = self.app.post_json(
-            '/auctions/{}/awards'.format(
-                self.auction_id), {
-                'data': {
-                    'suppliers': [test_organization], 'status': 'pending', 'bid_id': self.initial_bids[0]['id']}})
-        award = response.json['data']
-        self.award_id = award['id']
-        response = self.app.patch_json(
-            '/auctions/{}/awards/{}'.format(
-                self.auction_id, self.award_id), {
-                "data": {
-                    "status": "active"}})
+        fixtures.create_award( self)
         # Create contract for award
-        response = self.app.post_json(
-            '/auctions/{}/contracts'.format(
-                self.auction_id), {
-                'data': {
-                    'title': 'contract title', 'description': 'contract description', 'awardID': self.award_id}})
-        contract = response.json['data']
-        self.contract_id = contract['id']
+        self.app.patch_json('/auctions/{}/awards/{}?acc_token={}'.format(
+            self.auction_id,
+            self.award_id,
+            self.auction_token
+        ), {"data": {"status": "active"}})
+        response = self.app.get(
+            '/auctions/{}/contracts'.format(self.auction_id)
+        )
+        self.contract = response.json['data'][0]
+        self.contract_id = self.contract['id']
 
 
 class Auction2LotContractDocumentResourceTest(
         BaseAuctionWebTest,
         Auction2LotContractDocumentResourceTestMixin):
-    initial_status = 'active.qualification'
+    initial_status = 'active.auction'
     initial_bids = test_bids
     initial_lots = 2 * test_lots
 
     def setUp(self):
         super(Auction2LotContractDocumentResourceTest, self).setUp()
         # Create award
-        response = self.app.post_json('/auctions/{}/awards'.format(self.auction_id), {'data': {
-            'suppliers': [test_organization],
-            'status': 'pending',
-            'bid_id': self.initial_bids[0]['id'],
-            'lotID': self.initial_lots[0]['id']
-        }})
-        award = response.json['data']
-        self.award_id = award['id']
-        self.app.patch_json('/auctions/{}/awards/{}'.format(self.auction_id,
-                                                            self.award_id), {"data": {"status": "active"}})
+        fixtures.create_award( self)
         # Create contract for award
-        response = self.app.post_json(
-            '/auctions/{}/contracts'.format(
-                self.auction_id), {
-                'data': {
-                    'title': 'contract title', 'description': 'contract description', 'awardID': self.award_id}})
-        contract = response.json['data']
-        self.contract_id = contract['id']
+        self.app.patch_json(
+            '/auctions/{}/awards/{}?acc_token={}'.format(
+                self.auction_id,
+                self.award_id,
+                self.auction_token
+            ),
+            {"data": {"status": "active"}}
+        )
+        response = self.app.get(
+            '/auctions/{}/contracts'.format(self.auction_id)
+        )
+        self.contract = response.json['data'][0]
+        self.contract_id = self.contract['id']
 
 
 def suite():

--- a/openprocurement/auctions/flash/tests/contract.py
+++ b/openprocurement/auctions/flash/tests/contract.py
@@ -22,7 +22,6 @@ from openprocurement.auctions.core.plugins.contracting.v1.tests.contract import 
 from openprocurement.auctions.flash.tests import fixtures
 from openprocurement.auctions.flash.tests.base import (
     BaseAuctionWebTest,
-    test_auction_data,
     test_bids,
     test_lots,
     test_organization
@@ -96,7 +95,7 @@ class AuctionContractDocumentResourceTest(
     def setUp(self):
         super(AuctionContractDocumentResourceTest, self).setUp()
         # Create award
-        fixtures.create_award( self)
+        fixtures.create_award(self)
         # Create contract for award
         self.app.patch_json('/auctions/{}/awards/{}?acc_token={}'.format(
             self.auction_id,
@@ -120,7 +119,7 @@ class Auction2LotContractDocumentResourceTest(
     def setUp(self):
         super(Auction2LotContractDocumentResourceTest, self).setUp()
         # Create award
-        fixtures.create_award( self)
+        fixtures.create_award(self)
         # Create contract for award
         self.app.patch_json(
             '/auctions/{}/awards/{}?acc_token={}'.format(

--- a/openprocurement/auctions/flash/tests/fixtures.py
+++ b/openprocurement/auctions/flash/tests/fixtures.py
@@ -78,7 +78,6 @@ def create_award(test_case):
     test_case.second_bid_token = test_case.initial_bids_tokens.items()[1][1]
     test_case.app.authorization = authorization
 
-
     # response = test_case.app.post(
     #     '/auctions/{}/awards/{}/documents?acc_token={}'.format(
     #         test_case.auction_id,

--- a/openprocurement/auctions/flash/tests/fixtures.py
+++ b/openprocurement/auctions/flash/tests/fixtures.py
@@ -29,85 +29,109 @@ def create_award(test_case):
     authorization = test_case.app.authorization
     test_case.app.authorization = ('Basic', ('auction', ''))
     now = get_now()
-    auction_result = {
-        'bids': [
-            {
-                "id": b['id'],
-                "date": (now - timedelta(seconds=i)).isoformat(),
-                "value": b['value']
-            }
-            for i, b in enumerate(test_case.initial_bids)
-        ]
-    }
+    if test_case.initial_lots:
+        auction_result = {
+            'bids': [
+                {
+                    "id": b['id'],
+                    "date": (now - timedelta(seconds=i)).isoformat(),
+                    "lotValues": [{'value': item['value']} for item in b['lotValues']]
+                }
+                for i, b in enumerate(test_case.initial_bids)
+            ]
+        }
+        auction = test_case.db.get(test_case.auction_id)
+        for lot in auction['lots']:
+            lot.update({
+                "auctionPeriod": {
+                    "startDate": (now - timedelta(days=1)).isoformat(),
+                    "endDate": now.isoformat()
+                }
+            })
+        test_case.db.save(auction)
+    else:
+        auction_result = {
+            'bids': [
+                {
+                    "id": b['id'],
+                    "date": (now - timedelta(seconds=i)).isoformat(),
+                    "value": b['value']
+                }
+                for i, b in enumerate(test_case.initial_bids)
+            ]
+        }
 
     response = test_case.app.post_json(
         '/auctions/{}/auction'.format(test_case.auction_id),
         {'data': auction_result}
     )
-    test_case.assertEqual(response.status, '200 OK')
     auction = response.json['data']
-    test_case.app.authorization = authorization
-    test_case.award = auction['awards'][0]
-    test_case.award_id = test_case.award['id']
-    test_case.award_value = test_case.award['value']
-    test_case.award_suppliers = test_case.award['suppliers']
-
-    test_case.set_status('active.qualification')
-
-    test_case.app.authorization = ('Basic', ('token', ''))
-    response = test_case.app.post(
-        '/auctions/{}/awards/{}/documents?acc_token={}'.format(
-            test_case.auction_id,
-            test_case.award_id,
-            test_case.auction_token
-        ),
-        upload_files=[('file', 'auction_protocol.pdf', 'content')]
-    )
-    test_case.assertEqual(response.status, '201 Created')
-    test_case.assertEqual(response.content_type, 'application/json')
-    doc_id = response.json["data"]['id']
-
-    response = test_case.app.patch_json(
-        '/auctions/{}/awards/{}/documents/{}?acc_token={}'.format(
-            test_case.auction_id,
-            test_case.award_id,
-            doc_id,
-            test_case.auction_token
-        ),
-        {"data": {
-            "description": "auction protocol",
-            "documentType": 'auctionProtocol'
-        }}
-    )
     test_case.assertEqual(response.status, '200 OK')
-    test_case.assertEqual(response.content_type, 'application/json')
-    test_case.assertEqual(
-        response.json["data"]["documentType"],
-        'auctionProtocol'
-    )
-    test_case.assertEqual(response.json["data"]["author"], 'auction_owner')
+    test_case.assertEqual('active.qualification', auction["status"])
+    test_case.first_award = auction['awards'][0]
+    test_case.award = auction['awards'][0]
+    # test_case.second_award = auction['awards'][1]
+    test_case.first_award_id = test_case.first_award['id']
+    test_case.award_id = test_case.first_award_id
+    # test_case.second_award_id = test_case.second_award['id']
+    test_case.first_bid_token = test_case.initial_bids_tokens.items()[0][1]
+    test_case.second_bid_token = test_case.initial_bids_tokens.items()[1][1]
+    test_case.app.authorization = authorization
 
-    test_case.app.patch_json(
-        '/auctions/{}/awards/{}'.format(
-            test_case.auction_id,
-            test_case.award_id
-        ),
-        {"data": {"status": "pending"}}
-    )
-    test_case.app.patch_json(
-        '/auctions/{}/awards/{}'.format(
-            test_case.auction_id,
-            test_case.award_id
-        ),
-        {"data": {"status": "active"}}
-    )
-    get_auction_response = test_case.app.get(
-        '/auctions/{}'.format(
-            test_case.auction_id,
-        )
-    )
-    test_case.award_contract_id = get_auction_response.\
-        json['data']['contracts'][0]['id']
+
+    # response = test_case.app.post(
+    #     '/auctions/{}/awards/{}/documents?acc_token={}'.format(
+    #         test_case.auction_id,
+    #         test_case.award_id,
+    #         test_case.auction_token
+    #     ),
+    #     upload_files=[('file', 'auction_protocol.pdf', 'content')]
+    # )
+    # test_case.assertEqual(response.status, '201 Created')
+    # test_case.assertEqual(response.content_type, 'application/json')
+    # doc_id = response.json["data"]['id']
+    #
+    # response = test_case.app.patch_json(
+    #     '/auctions/{}/awards/{}/documents/{}?acc_token={}'.format(
+    #         test_case.auction_id,
+    #         test_case.award_id,
+    #         doc_id,
+    #         test_case.auction_token
+    #     ),
+    #     {"data": {
+    #         "description": "auction protocol",
+    #         "documentType": 'auctionProtocol'
+    #     }}
+    # )
+    # test_case.assertEqual(response.status, '200 OK')
+    # test_case.assertEqual(response.content_type, 'application/json')
+    # test_case.assertEqual(
+    #     response.json["data"]["documentType"],
+    #     'auctionProtocol'
+    # )
+    # test_case.assertEqual(response.json["data"]["author"], 'auction_owner')
+    #
+    # test_case.app.patch_json(
+    #     '/auctions/{}/awards/{}'.format(
+    #         test_case.auction_id,
+    #         test_case.award_id
+    #     ),
+    #     {"data": {"status": "pending"}}
+    # )
+    # test_case.app.patch_json(
+    #     '/auctions/{}/awards/{}'.format(
+    #         test_case.auction_id,
+    #         test_case.award_id
+    #     ),
+    #     {"data": {"status": "active"}}
+    # )
+    # get_auction_response = test_case.app.get(
+    #     '/auctions/{}'c.format(
+    #         test_case.auction_id,
+    #     )
+    # )
+    # test_case.award_contract_id = get_auction_response.\
+    #     json['data']['contracts'][0]['id']
 
 
 def create_prolongation(test_case, test_case_attr):

--- a/openprocurement/auctions/flash/tests/lot.py
+++ b/openprocurement/auctions/flash/tests/lot.py
@@ -27,6 +27,7 @@ from openprocurement.auctions.flash.tests.blanks.lot_blanks import (
 )
 
 
+@unittest.skip('lot creation by broker is not allowed')
 class AuctionLotResourceTest(BaseAuctionWebTest, AuctionLotResourceTestMixin):
     test_lots = test_lots
     test_auction_data = test_auction_data
@@ -58,7 +59,9 @@ class AuctionLotFeatureBidderResourceTest(BaseAuctionWebTest):
     def setUp(self):
         super(AuctionLotFeatureBidderResourceTest, self).setUp()
         self.lot_id = self.initial_lots[0]['id']
-        response = self.app.patch_json('/auctions/{}'.format(self.auction_id), {"data": {
+        response = self.app.patch_json('/auctions/{}?acc_token={}'.format(
+            self.auction_id, self.auction_token
+        ), {"data": {
             "items": [
                 {
                     'relatedLot': self.lot_id,


### PR DESCRIPTION
Remove usage of 'admins' token in tests

### Depends on:

- https://github.com/openprocurement/openprocurement.auctions.core/pull/152

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.auctions.flash/63)
<!-- Reviewable:end -->
